### PR TITLE
fix(keyframes): fix keyframes can't convert problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,7 @@ const px2vw = px => Number(px) ? `${Math.round(Number(px) / 7.5 * 100000) / 1000
 const convertStringPx2vw = style => {
     if (!style) return style;
 
-    if (Object.prototype.toString.call(style) === '[object Object]'
-        && style.constructor.name === 'Keyframes') {
-
-        style.rules = style.rules.map(convertStringPx2vw);
-        return style;
-    } else if (
+    if (
         !base64Re.test(style)   // 非base64字符串
         && pxRe.test(style)     // 包含px单位
     ) {
@@ -25,7 +20,15 @@ const convertStringPx2vw = style => {
 }
 
 const convertInterpolationPx2vw = interpolation => {
-    if (typeof interpolation !== 'function') return interpolation;
+    if (Object.prototype.toString.call(interpolation) === '[object Object]'
+        && interpolation.constructor.name === 'Keyframes') {
+
+        interpolation.rules = interpolation.rules.map(convertStringPx2vw);
+
+        return interpolation;
+    } else if (typeof interpolation !== 'function') {
+        return interpolation;
+    }
 
     return props => {
         const result = interpolation(props);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "styled-px2vw",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Extension of styled-components with features for convert px to vw units",
     "main": "lib/index.js",
     "module": "es/index.js",


### PR DESCRIPTION
`Keyframes` is one of interpolations, so we need to convert its' rules in `convertInterpolationPx2vw` rather than `convertStringPx2vw`.

I test it myself, looking forward to more test.